### PR TITLE
Badge to show you're free of known vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This client currently only implements the read methods of the [v2 Bandiera API][
 [![Build status][shield-build]][info-build]
 [![Dependencies][shield-dependencies]][info-dependencies]
 [![MIT licensed][shield-license]][info-license]
+[![Known Vulnerabilities](https://snyk.io/test/github/springernature/bandiera-client-node/3fc231c72dea27100d49f6d5b5fb851b71083e7a/badge.svg)](https://snyk.io/test/github/springernature/bandiera-client-node/3fc231c72dea27100d49f6d5b5fb851b71083e7a)
 
 
 Installation


### PR DESCRIPTION
bandiera-client-node has no vulnerabilities, which is awesome! 

This PR adds a badge that shows you're free of known vulnerabilities. Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Adding the badge will show others that you care about security, and that they should care, too. 
(it will also help to spread the word about Snyk, which would help us a lot!).