### PR TITLE
updates request dependency, other changes for a version 3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = false
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ matrix:
   include:
 
     # Run linter once
-    - node_js: '0.12'
+    - node_js: '4'
       env: LINT=true
 
     # Run tests
-    - node_js: '0.10'
-    - node_js: '0.12'
     - node_js: '4'
-    - node_js: '5'
     - node_js: '6'
+    - node_js: '8'
 
 # Restrict builds on branches
 branches:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ make lint test
 License
 -------
 
-Copyright &copy; 2017 Springer Nature.  
+Copyright &copy; 2018 Springer Nature.
 Node Bandiera client is licensed under the [MIT License][info-license].
 
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "bandiera-client",
-	"version": "2.4.7",
-
+	"version": "3.0.0",
 	"description": "Bandiera is a simple, stand-alone feature flagging service that is not tied to any existing web framework or language. This is a client for talking to the web service.",
-	"keywords": [ "feature", "flagging" ],
-
+	"keywords": [
+		"feature",
+		"flagging"
+	],
 	"author": "Springer Nature",
 	"contributors": [
 		"Rowan Manning (http://rowanmanning.com/)",
 		"Andrew Walker (http://www.moddular.org/)"
 	],
-
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/springernature/bandiera-client-node.git"
@@ -18,13 +18,12 @@
 	"homepage": "https://github.com/springernature/bandiera-client-node",
 	"bugs": "https://github.com/springernature/bandiera-client-node/issues",
 	"license": "MIT",
-
 	"engines": {
-		"node": ">=0.10"
+		"node": ">=4"
 	},
 	"dependencies": {
 		"node.extend": "~1.1.0",
-		"request": "~2.79.0"
+		"request": "~2.87.0"
 	},
 	"devDependencies": {
 		"istanbul": "~0.4.5",
@@ -35,7 +34,6 @@
 		"proclaim": "^3",
 		"sinon": "^1"
 	},
-
 	"main": "./lib/client.js",
 	"scripts": {
 		"test": "make test"


### PR DESCRIPTION
This PR is intended to drop support for node versions < 4.
This is so we can hike the `request` dependency to a recent version (which is incompatible with node <4), which we need to do for security reasons.

This PR will be a breaking change, and released as v3.

1. `"engines": {"node": ">=4"}`
1. stop Travis running tests on node <4, drops node 5, adds tests for node 8
1. hikes `request` to a recent version
1. copyright year++
1. adds `.editorconfig`